### PR TITLE
Changed ID-based URL to filename-based

### DIFF
--- a/include/httpfileserver.h
+++ b/include/httpfileserver.h
@@ -2,12 +2,20 @@
 #define HTTPFILESERVER_H
 
 #include <QtNetwork>
+#include <QString>
+
 class HttpFileServer : public QObject
 {
     Q_OBJECT
 public:
     HttpFileServer(int port, QHostAddress address, QObject *parent = 0);
     int serveFile(QUrl path);
+    /**
+     * @brief Returns the full filename of the given ID
+     * @param id The ID of the file
+     * @return Full filename of the file
+     */
+    QString getFilenameFromID(int id);
 private:
     QTcpServer *server;
 private slots:

--- a/src/httpfileserver.cpp
+++ b/src/httpfileserver.cpp
@@ -32,10 +32,13 @@ void HttpFileServer::handleIncoming()
             if(line.startsWith("GET /")){
                 line.replace("GET /", ""); // HTTP header left part
                 line.chop(11); // HTTP header right part
-                filePath = fileMap[line.split(".").first().toInt()];
+                int id = line.left(line.lastIndexOf("/")).toInt();
+                QString fileName = line.right(line.length() - line.lastIndexOf("/") - 1);
+                filePath = fileMap[id];
                 // Checks, is file valid
                 fileinfo.setFile(filePath.toString());
                 if(fileinfo.suffix() != line.split(".").last() ||
+                        fileinfo.fileName() != fileName ||
                         !fileinfo.exists() ||
                         !fileinfo.isFile() ||
                         !fileinfo.isReadable() ) { error = true; continue; }
@@ -97,4 +100,10 @@ int HttpFileServer::serveFile(QUrl path)
 {
     fileMap.insert(fileMap.count(), path);
     return fileMap.count() - 1;
+}
+
+QString HttpFileServer::getFilenameFromID(int id)
+{
+    QUrl file(fileMap[id]);
+    return file.fileName();
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -19,11 +19,11 @@ Server::Server(QCoreApplication &core, QObject *parent) : QObject(parent)
 }
 void Server::foundRenderer(DLNARenderer *server){
     // Get local adress
-    foreach(const QString &file, filesList) {
-        QString id = QString::number(fileServer->serveFile(QUrl(file))); // File to serve
-        server->setPlaybackUrl( QUrl("http://"+getLocalAddress().toString()+":"+QString::number(port)+"/"+id+".mp4") ); // Eh, need to be made better
-        server->playPlayback();
-    }
+    int id = fileServer->serveFile(QUrl(filesList[0])); // File to serve
+    QString fileName = fileServer->getFilenameFromID(id);
+    server->setPlaybackUrl(QUrl("http://"+getLocalAddress().toString()+":"+
+                                QString::number(port)+"/"+QString::number(id)+"/"+fileName)); // Eh, need to be made better
+    server->playPlayback();
 }
 QHostAddress Server::getLocalAddress() {
     // @see http://stackoverflow.com/questions/13835989/get-local-ip-address-in-qt


### PR DESCRIPTION
Fixes #1.

Earlier, the Renderer showed the video as `id.extension`, but now it is changed to `filename.extension`.

URL changed from `/id.extension` to `/id/filename.extension`.