### PR TITLE
Added an XML action-data generator

### DIFF
--- a/include/SOAPActionManager.h
+++ b/include/SOAPActionManager.h
@@ -16,7 +16,7 @@ class SOAPActionManager : public QObject
     Q_OBJECT
 public:
     explicit SOAPActionManager(QObject *parent = 0);
-    void doAction(const QString & action, const QString & actionData, const QUrl & controlUrl);
+    void doAction(const QString &action, const QMap<QString, QString> &dataMap, const QUrl &controlUrl);
 signals:
     void receivePlaybackInfo(DLNAPlaybackInfo*);
 private:

--- a/src/DLNARenderer.cpp
+++ b/src/DLNARenderer.cpp
@@ -22,46 +22,55 @@ void DLNARenderer::setControlUrl(const QString & url)
 
 void DLNARenderer::setPlaybackUrl(const QUrl & url)
 {
+    QMap<QString, QString> dataMap;
+    dataMap.insert("CurrentURI", "<![CDATA["+url.toString()+"]]>");
+    dataMap.insert("CurrentURIMetaData", "");
     sam->doAction(
                 "SetAVTransportURI", // Action
-                "<CurrentURI><![CDATA["+url.toString()+"]]></CurrentURI><CurrentURIMetaData></CurrentURIMetaData>",  // Action Data
+                dataMap,  // Action Data
                 fullcontrolUrl); // Control url
 }
 
 void DLNARenderer::setNextPlaybackUrl(const QUrl & url)
 {
-    sam->doAction(
-                "SetNextAVTransportURI", // Action
-                "<NextURI>"+url.toString()+"</NextURI><NextURIMetaData></NextURIMetaData>",  // Action Data
-                fullcontrolUrl); // Control url
+    QMap<QString, QString> dataMap;
+    dataMap.insert("NextURI", url.toString());
+    dataMap.insert("NextURIMetaData", "");
+    sam->doAction("SetNextAVTransportURI", dataMap, fullcontrolUrl);
 }
 
 void DLNARenderer::queryPlaybackInfo()
 {
-    sam->doAction("GetPositionInfo", "", fullcontrolUrl);
+    sam->doAction("GetPositionInfo", QMap<QString, QString>(), fullcontrolUrl);
 }
 
 void DLNARenderer::playPlayback()
 {
-    sam->doAction("Play", "<Speed>1</Speed>", fullcontrolUrl);
+    QMap<QString, QString> dataMap;
+    dataMap.insert("Speed", "1");
+    sam->doAction("Play", dataMap, fullcontrolUrl);
 }
 
 void DLNARenderer::pausePlayback()
 {
-    sam->doAction("Pause", "", fullcontrolUrl);
+    sam->doAction("Pause", QMap<QString, QString>(), fullcontrolUrl);
 }
 
 void DLNARenderer::previousPlayback()
 {
-    sam->doAction("Previous", "", fullcontrolUrl);
+    sam->doAction("Previous", QMap<QString, QString>(), fullcontrolUrl);
 }
 
 void DLNARenderer::nextPlayback()
 {
-    sam->doAction("Next", "", fullcontrolUrl);
+    sam->doAction("Next", QMap<QString, QString>(), fullcontrolUrl);
 }
 
 void DLNARenderer::seekPlayback(QTime time)
 {
-    sam->doAction("Seek", "<InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>"+time.toString()+"</Target>", fullcontrolUrl);
+    QMap<QString, QString> dataMap;
+    dataMap.insert("InstanceID", "0");
+    dataMap.insert("Unit", "REL_TIME");
+    dataMap.insert("Target", time.toString());
+    sam->doAction("Seek", dataMap, fullcontrolUrl);
 }

--- a/src/SOAPActionManager.cpp
+++ b/src/SOAPActionManager.cpp
@@ -11,9 +11,19 @@ SOAPActionManager::SOAPActionManager(QObject *parent) : QObject(parent)
     mgr = new QNetworkAccessManager(this);
 }
 
-void SOAPActionManager::doAction(const QString & action, const QString & actionData, const QUrl & controlUrl)
+void SOAPActionManager::doAction(const QString &action, const QMap<QString, QString> &dataMap, const QUrl &controlUrl)
 {
     QNetworkRequest request;
+
+    // Build xml data string
+    QString actionData = "";
+    if (!dataMap.isEmpty() || !dataMap.isDetached()) {
+        for (const QString &key : dataMap.keys()) {
+            actionData.append("<" + key + ">");
+            actionData.append(dataMap.value(key));
+            actionData.append("</" + key + ">");
+        }
+    }
 
     // Build xml request body
     QString data = SOAPXmlHeader + action + SOAPXmlInstanceId + actionData + SOAPXmlActions + action + SOAPXmlFooter;


### PR DESCRIPTION
Now, the XML action data is generated automatically from a data set.

To use it, create a `QMap<QString, QString>` and then pass it to the `SOAPActionManager`.